### PR TITLE
Update PCControllerDriver.groovy: Convert boolean attribute to enum

### DIFF
--- a/ComputerController/ComputerControllerDriver.groovy
+++ b/ComputerController/ComputerControllerDriver.groovy
@@ -28,9 +28,9 @@ metadata {
         command "AddStringParam",[[name:"Value*", type: "STRING", description: "Enter value", required: true ]]
         command "AddNumberParam",[[name:"Value*", type: "NUMBER", description: "Enter value", required: true ]]
         command "ClearParams"
-        attribute "Connected", "boolean"
+        attribute "Connected", "enum", ["true", "false"]
         attribute "EG Plugin Version", "string"
-        attribute "EG Plugin Outdated", "boolean"
+        attribute "EG Plugin Outdated", "enum", ["true","false"]
         attribute "ReceivedCommand", "string"
         attribute "ReceivedParam1", "string"
         attribute "ReceivedParam2", "string"
@@ -144,17 +144,17 @@ def comparePluginVersion(newVer) {
         def outdated = pluginVersion[device.id][1]<verNum   
         if (outdated) {
             sendEvent(name: "EG Plugin Version", value: pluginVersion[device.id][0] + " (outdated, please update to " + newVer[1] +")")
-            sendEvent(name: "EG Plugin Outdated", value:true)
+            sendEvent(name: "EG Plugin Outdated", value:"true")
         }
         else {
             sendEvent(name: "EG Plugin Version", value: pluginVersion[device.id][0] + " (Latest version)")
-            sendEvent(name: "EG Plugin Outdated", value:false)
+            sendEvent(name: "EG Plugin Outdated", value:"false")
         }
          
     } 
     else {
         sendEvent(name: "EG Plugin Version", value: "1.0.1 (outdated, please update to " + newVer[1] +")")
-        sendEvent(name: "EG Plugin Outdated", value:true)
+        sendEvent(name: "EG Plugin Outdated", value:"true")
     }
     
 }
@@ -248,27 +248,27 @@ def webSocketStatus(String status){
 
     if(status.startsWith('failure: ')) {
         connected[device.id] = false
-        sendEvent(name: "Connected", value: false)
+        sendEvent(name: "Connected", value: "false")
         log.warn("failure message from web socket ${status}")
  
        reconnect()
     } 
     else if(status == 'status: open') {
         log.info "websocket is open"
-        sendEvent(name: "Connected", value: true)
+        sendEvent(name: "Connected", value: "true")
         connected[device.id] = true
         onConnected()
       
     } 
     else if (status == "status: closing"){
-        sendEvent(name: "Connected", value: false)
+        sendEvent(name: "Connected", value: "false")
         connected[device.id] = false
         log.warn "WebSocket connection closing."
          reconnect()
        
     } 
     else {
-        sendEvent(name: "Connected", value: false)
+        sendEvent(name: "Connected", value: "false")
         connected[device.id] = false
         log.warn "WebSocket error, reconnecting."
         reconnect()


### PR DESCRIPTION
…enum

Because of the way Rule Machine and other apps set/get device attribute values, the Hubitat platform requires preset values to be listed within an enum structure. This applies to true/false values as well, which should be treated as strings rather than Boolean truth values.  I'm proposing such changes to two of the attributes in PC Controller's device driver for maximum compatibility and to avoid certain warnings in RM5.1. Unfortunately, it's unclear whether @gilshallem is still active on github, as he seems to have left the Hubitat Community years ago, and I've been unable to reach him through other channels for a while now. If it's helpful to all parties involved, I'd gladly "adopt" (maintain) this particular integration going forward.